### PR TITLE
Add some CI/CD support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,26 @@
+before_install:
+  - sudo apt-get install -y gcc-arm-none-eabi libnewlib-arm-none-eabi
+language: c
+script:
+ - make -C ble-host/build/gcc
+ - make -C controller/build/gcc
+ - make -C projects/ble-apps/assettag/gcc
+ - make -C projects/ble-apps/cycling/gcc
+ - make -C projects/ble-apps/datc/gcc
+ - make -C projects/ble-apps/dats/gcc
+ - make -C projects/ble-apps/fit/gcc
+ - make -C projects/ble-apps/hidapp/gcc
+ - make -C projects/ble-apps/locator/gcc
+ - make -C projects/ble-apps/medc/gcc
+ - make -C projects/ble-apps/meds/gcc
+ - make -C projects/ble-apps/tag/gcc
+ - make -C projects/ble-apps/uribeacon/gcc
+ - make -C projects/ble-apps/watch/gcc
+ - make -C projects/ble-mesh-apps/lib/gcc
+ - make -C projects/ble-mesh-apps/light/gcc
+ - make -C projects/ble-mesh-apps/provisioner/gcc
+ - make -C projects/ble-mesh-apps/switch/gcc
+ - make -C projects/controller/ble4-ctr/gcc
+ - make -C projects/controller/ble5-ctr/gcc
+# - make -C projects/controller/mac154-ctr/gcc  # link error
+ - make -C wsf/build/gcc

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/packetcraft-inc/cordio.svg?branch=master)](https://travis-ci.org/packetcraft-inc/cordio)
+
 ## Arm Cordio solutions
 
 Arm Cordio is a collection of Bluetooth Low Energy embedded protocol stacks. Included in these


### PR DESCRIPTION
In order for this to work, you need to log into https://travis-ci.org/ with your packetcraft-inc github account and enable the 'cordio' project from there. Look at the settings for interesting options.

I also added a Travis CI badge in README.md so to show how good is the health of your code base.

There is a commented out target [(projects/controller/mac154-ctr/gcc)](https://github.com/packetcraft-inc/cordio/tree/master/projects/controller/mac154-ctr/gcc) which fails to build with:

> ```/tmp/ccdSsYdU.ltrans0.ltrans.o: In function `Reset_Handler':
><artificial>:(.text+0x55e): undefined reference to `main'
>collect2: error: ld returned 1 exit status
> ../../../../platform/nordic/build/build.mk:193: recipe for target 'bin/mac154-ctr.elf' failed
> make: *** [bin/mac154-ctr.elf] Error 1```